### PR TITLE
Fix osediff_path and BertTokenizer path

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
 python test_osediff.py \
 -i preset/datasets/test_dataset/input \
 -o preset/datasets/test_dataset/output \
---osediff_path preset\models\osediff.pkl \
+--osediff_path preset/models/osediff.pkl \
 --pretrained_model_name_or_path SD21BASE_PATH \
 --ram_ft_path DAPE_PATH \
 --ram_path RAM_PATH

--- a/ram/models/utils.py
+++ b/ram/models/utils.py
@@ -129,7 +129,7 @@ class GroupWiseLinear(nn.Module):
 
 def init_tokenizer():
     # tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
-    tokenizer = BertTokenizer.from_pretrained('/home/notebook/data/group/LowLevelLLM/LLM/bert-base-uncased', local_files_only=True)
+    tokenizer = BertTokenizer.from_pretrained('google-bert/bert-base-uncased')
     tokenizer.add_special_tokens({'bos_token': '[DEC]'})
     tokenizer.add_special_tokens({'additional_special_tokens': ['[ENC]']})
     tokenizer.enc_token_id = tokenizer.additional_special_tokens_ids[0]


### PR DESCRIPTION
When running on Ubuntu, I encountered the following error:

`
FileNotFoundError: [Errno 2] No such file or directory: 'presetmodelsosediff.pkl'
`

osediff_path should use `preset/models/osediff.pkl` instead of `preset\models\osediff.pkl`. 

And change the path of the `BertTokenizer` from the local path to the repo id on the huggingface.